### PR TITLE
Add openssf scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,7 +2,9 @@ name: Scorecard analysis
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - openssf-workflow
   branch_protection_rule:
   schedule:
     - cron: "30 1 * * 6"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,7 +2,7 @@ name: Scorecard analysis
 
 on:
   push:
-    branches: [main].
+    branches: [main]
   branch_protection_rule:
   schedule:
     - cron: "30 1 * * 6"
@@ -15,8 +15,11 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
-      id-token: write
+      issues: read
+      pull-requests: read
+      checks: read
 
     steps:
       - name: "Checkout code"
@@ -29,7 +32,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          publish_results: false
       - name: "Upload artifact"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,9 +2,7 @@ name: Scorecard analysis
 
 on:
   push:
-    branches:
-      - main
-      - openssf-workflow
+    branches: [main]
   branch_protection_rule:
   schedule:
     - cron: "30 1 * * 6"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: Scorecard analysis
+
+on:
+  push:
+    branches: [main].
+  branch_protection_rule:
+  schedule:
+    - cron: "30 1 * * 6"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Add openssf scorecard workflow

## Summary by Sourcery

Add automated OpenSSF Scorecard analysis to monitor repository security practices.

New Features:
- Add a GitHub Actions workflow that runs OpenSSF Scorecard security analysis on repository changes and on a weekly schedule.

CI:
- Configure Scorecard results to be retained as an artifact and uploaded to GitHub code scanning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated OSSF Scorecard security analysis for the main branch, scheduled runs, and manual execution.
  * Security findings are published to code scanning for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->