### PR TITLE
Extend test coverage

### DIFF
--- a/src/cla-bot.js
+++ b/src/cla-bot.js
@@ -1015,4 +1015,5 @@ module.exports = {
   getSignaturesToken,
   postComment,
   validateConfig,
+  lockPR,
 };

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -530,6 +530,241 @@ function fakeResponse(status, jsonBody, headers = {}) {
     );
   });
 
+  // -------------------------------------------------------------------------
+  // Timeout behavior. ghRaw() wires every fetch() to an AbortController that
+  // fires after REQUEST_TIMEOUT_MS (15s) - a hung call must not stall the
+  // job forever, and the resulting AbortError must be treated as transient
+  // by gh()'s retry loop just like a 5xx. REQUEST_TIMEOUT_MS is a fixed
+  // constant (not env-configurable), so rather than actually waiting 15
+  // real seconds per attempt, these tests stub global.setTimeout to fire
+  // immediately - the real AbortController/signal wiring and retry logic
+  // still run for real, only the wall-clock wait is skipped.
+  // -------------------------------------------------------------------------
+  await test("a hung request is aborted after the configured timeout, and the AbortError is retried like other transient failures until it propagates", async () => {
+    const originalSetTimeout = global.setTimeout;
+    global.setTimeout = (fn) => originalSetTimeout(fn, 0);
+    let fetchCalls = 0;
+    try {
+      global.fetch = (url, opts) =>
+        new Promise((resolve, reject) => {
+          fetchCalls += 1;
+          // A request that never resolves on its own - the only way it
+          // ever settles is via the abort signal ghRaw() attaches, exactly
+          // like a real hung connection behaves under fetch+AbortController.
+          opts.signal.addEventListener("abort", () => {
+            const err = new Error("This operation was aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        });
+
+      let caught = null;
+      try {
+        await readSignatures("tok");
+      } catch (e) {
+        caught = e;
+      }
+      assert.ok(caught, "expected the call to eventually throw");
+      assert.strictEqual(caught.name, "AbortError");
+      assert.strictEqual(
+        fetchCalls,
+        3,
+        "AbortError must be retried up to MAX_RETRIES (3 total attempts), not thrown immediately and not retried forever",
+      );
+    } finally {
+      global.setTimeout = originalSetTimeout;
+    }
+  });
+
+  await test("the per-request abort timer is cleared after a normal (non-hung) response, not left dangling", async () => {
+    const originalClearTimeout = global.clearTimeout;
+    let clearedCount = 0;
+    global.clearTimeout = (id) => {
+      clearedCount += 1;
+      return originalClearTimeout(id);
+    };
+    try {
+      global.fetch = async () =>
+        fakeResponse(200, {
+          sha: "x",
+          content: b64({ version: 1, signatures: [] }),
+          encoding: "base64",
+        });
+      await readSignatures("tok");
+      assert.strictEqual(
+        clearedCount,
+        1,
+        "expected exactly one clearTimeout call for the one request readSignatures made - a leaked timer keeps the process alive longer than necessary",
+      );
+    } finally {
+      global.clearTimeout = originalClearTimeout;
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // gh()'s generic transient-failure retry loop (distinct from the
+  // 409-specific compare-and-swap retry inside writeSignatures tested above).
+  // -------------------------------------------------------------------------
+  await test("a transient 503 is retried and the call eventually succeeds", async () => {
+    const originalSetTimeout = global.setTimeout;
+    global.setTimeout = (fn) => originalSetTimeout(fn, 0);
+    let calls = 0;
+    try {
+      global.fetch = async () => {
+        calls += 1;
+        if (calls < 3)
+          return fakeResponse(503, { message: "Service Unavailable" });
+        return fakeResponse(200, {
+          sha: "recovered-sha",
+          content: b64({ version: 1, signatures: [] }),
+          encoding: "base64",
+        });
+      };
+      const { sha } = await readSignatures("tok");
+      assert.strictEqual(sha, "recovered-sha");
+      assert.strictEqual(
+        calls,
+        3,
+        "expected 2 failed attempts before the 3rd one succeeds",
+      );
+    } finally {
+      global.setTimeout = originalSetTimeout;
+    }
+  });
+
+  await test("a 429 rate-limit response is retried the same way as a 5xx", async () => {
+    const originalSetTimeout = global.setTimeout;
+    global.setTimeout = (fn) => originalSetTimeout(fn, 0);
+    let calls = 0;
+    try {
+      global.fetch = async () => {
+        calls += 1;
+        if (calls === 1) return fakeResponse(429, { message: "rate limited" });
+        return fakeResponse(200, {
+          sha: "x",
+          content: b64({ version: 1, signatures: [] }),
+          encoding: "base64",
+        });
+      };
+      await readSignatures("tok");
+      assert.strictEqual(calls, 2);
+    } finally {
+      global.setTimeout = originalSetTimeout;
+    }
+  });
+
+  await test("gh() honors the Retry-After header for the backoff delay on a secondary rate limit (403 + retry-after), instead of the default attempt*1000 delay", async () => {
+    const originalSetTimeout = global.setTimeout;
+    const delaysSeen = [];
+    global.setTimeout = (fn, ms) => {
+      delaysSeen.push(ms);
+      return originalSetTimeout(fn, 0); // fast-forward so the test doesn't actually wait
+    };
+    let calls = 0;
+    try {
+      global.fetch = async () => {
+        calls += 1;
+        if (calls === 1)
+          return fakeResponse(
+            403,
+            { message: "secondary rate limit" },
+            { "retry-after": "2" },
+          );
+        return fakeResponse(200, {
+          sha: "x",
+          content: b64({ version: 1, signatures: [] }),
+          encoding: "base64",
+        });
+      };
+      await readSignatures("tok");
+      // Two kinds of setTimeout calls happen here: the 15s abort timer for
+      // each fetch, and the one retry backoff delay between attempt 1 and
+      // attempt 2. That backoff delay should be retryAfter*1000 = 2000, not
+      // the default attempt*1000 = 1000.
+      assert.ok(
+        delaysSeen.includes(2000),
+        `expected a 2000ms backoff delay honoring Retry-After: 2, saw: ${delaysSeen}`,
+      );
+    } finally {
+      global.setTimeout = originalSetTimeout;
+    }
+  });
+
+  await test("a POST (e.g. posting a comment) is NOT retried by default on a transient 5xx, since a blind retry could create a duplicate", async () => {
+    let postAttempts = 0;
+    global.fetch = async (url, opts) => {
+      const method = (opts.method || "GET").toUpperCase();
+      if (method === "GET" && url.includes("/comments")) {
+        return fakeResponse(200, []); // dedupe pre-check: no existing comments
+      }
+      if (method === "POST") {
+        postAttempts += 1;
+        return fakeResponse(500, { message: "Internal Server Error" });
+      }
+      throw new Error(`unexpected call: ${method} ${url}`);
+    };
+    let caught = null;
+    try {
+      await postComment(1, "hello");
+    } catch (e) {
+      caught = e;
+    }
+    assert.ok(caught, "expected postComment to throw");
+    assert.strictEqual(caught.status, 500);
+    assert.strictEqual(
+      postAttempts,
+      1,
+      "a POST must be attempted exactly once on a transient failure - retrying it automatically risks creating a duplicate comment",
+    );
+  });
+
+  await test("a persistently-failing transient error (503) is retried up to MAX_RETRIES then propagates, not retried forever", async () => {
+    const originalSetTimeout = global.setTimeout;
+    global.setTimeout = (fn) => originalSetTimeout(fn, 0);
+    let calls = 0;
+    try {
+      global.fetch = async () => {
+        calls += 1;
+        return fakeResponse(503, { message: "Service Unavailable" });
+      };
+      let caught = null;
+      try {
+        await readSignatures("tok");
+      } catch (e) {
+        caught = e;
+      }
+      assert.ok(caught, "expected the call to eventually throw");
+      assert.strictEqual(caught.status, 503);
+      assert.strictEqual(
+        calls,
+        3,
+        "expected exactly MAX_RETRIES (3) attempts, not unlimited retries and not fewer",
+      );
+    } finally {
+      global.setTimeout = originalSetTimeout;
+    }
+  });
+
+  await test('readSignatures throws a descriptive error when the stored file\'s "signatures" field is not an array (corrupted/hand-edited data)', async () => {
+    global.fetch = async () =>
+      fakeResponse(200, {
+        sha: "corrupt-sha",
+        content: b64({ version: 1, signatures: { not: "an array" } }),
+        encoding: "base64",
+      });
+    let caught = null;
+    try {
+      await readSignatures("tok");
+    } catch (e) {
+      caught = e;
+    }
+    assert.ok(caught, "expected readSignatures to throw on corrupted data");
+    assert.ok(
+      /signatures.*is not an array/i.test(caught.message),
+      `expected a descriptive error naming the field, got: ${caught.message}`,
+    );
+  });
+
   console.log(`\n${passed} test(s) passed.`);
   if (process.exitCode) {
     console.error("\nSOME TESTS FAILED.");

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -23,6 +23,7 @@ process.env.ALLOWLIST = "";
 const {
   handleIssueComment,
   handlePullRequestTarget,
+  lockPR,
 } = require("../src/cla-bot.js");
 
 let passed = 0;
@@ -56,12 +57,15 @@ function makeFakeGitHub({
   initialSignatures,
   users = {},
   usersById = {},
+  lockShouldFail = false,
 }) {
   const state = {
     signatures: initialSignatures,
     sha: "sha-0",
     comments: [],
     statuses: [],
+    lockCalls: [],
+    lockShouldFail,
   };
 
   state.fetch = async (url, opts = {}) => {
@@ -144,8 +148,21 @@ function makeFakeGitHub({
     }
     if (url.includes("/statuses/")) {
       const payload = JSON.parse(opts.body);
-      state.statuses.push(payload);
+      // sha is only in the URL, not the body - capture it too so tests can
+      // assert which commit a status was posted against.
+      state.statuses.push({ ...payload, sha: url.split("/statuses/")[1] });
       return res(201, {});
+    }
+    if (url.includes("/lock")) {
+      if (method === "PUT") {
+        state.lockCalls.push(JSON.parse(opts.body || "{}"));
+        if (state.lockShouldFail) {
+          return res(403, {
+            message: "Resource not accessible by integration",
+          });
+        }
+        return res(204, null);
+      }
     }
     throw new Error(`Unhandled mock request: ${method} ${url}`);
   };
@@ -1022,6 +1039,212 @@ function makeFakeGitHub({
         );
         return true;
       },
+    );
+  });
+
+  // ---------------------------------------------------------------------
+  // lockPR: direct coverage. Production code is deliberately best-effort
+  // here (see lockPR's comment in src/cla-bot.js) - a failed lock call must
+  // never fail the whole run, only warn. Neither the success path nor the
+  // failure path had any dedicated coverage before.
+  // ---------------------------------------------------------------------
+  await test("lockPR locks the PR with lock_reason 'resolved'", async () => {
+    const gh = makeFakeGitHub({
+      commits: [],
+      initialSignatures: { version: 1, signatures: [] },
+    });
+    global.fetch = gh.fetch;
+
+    await lockPR(1);
+
+    assert.strictEqual(
+      gh.lockCalls.length,
+      1,
+      "expected exactly one lock call",
+    );
+    assert.strictEqual(gh.lockCalls[0].lock_reason, "resolved");
+  });
+
+  await test("lockPR is best-effort: an API failure is caught, logged as a warning, and does NOT throw or fail the run", async () => {
+    const gh = makeFakeGitHub({
+      commits: [],
+      initialSignatures: { version: 1, signatures: [] },
+      lockShouldFail: true,
+    });
+    global.fetch = gh.fetch;
+
+    const originalWarn = console.warn;
+    let warned = "";
+    console.warn = (msg) => {
+      warned = msg;
+    };
+    try {
+      await assert.doesNotReject(
+        () => lockPR(1),
+        "lockPR must never throw, even when the underlying API call fails - locking is nice-to-have hardening, not core to CLA correctness",
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.strictEqual(
+      gh.lockCalls.length,
+      1,
+      "the lock attempt should still have been made before it failed",
+    );
+    assert.ok(
+      warned.includes("Could not lock PR #1"),
+      `expected a warning naming the PR, got: ${warned}`,
+    );
+  });
+
+  // ---------------------------------------------------------------------
+  // handlePullRequestTarget: direct dispatch coverage. Previously only the
+  // malformed-payload guard was tested here - the real event-routing logic
+  // (opened/synchronize/reopened -> checkPR, closed+merged -> lockPR,
+  // everything else -> no-op) had no coverage at all.
+  // ---------------------------------------------------------------------
+  await test("handlePullRequestTarget locks the PR when a 'closed' event reports it was merged", async () => {
+    const gh = makeFakeGitHub({
+      commits: [],
+      initialSignatures: { version: 1, signatures: [] },
+    });
+    global.fetch = gh.fetch;
+
+    const payload = {
+      action: "closed",
+      pull_request: { number: 1, merged: true, head: { sha: "head-sha-x" } },
+    };
+    await handlePullRequestTarget(payload);
+
+    assert.strictEqual(
+      gh.lockCalls.length,
+      1,
+      "a merged, closed PR should be locked",
+    );
+    assert.strictEqual(
+      gh.statuses.length,
+      0,
+      "locking a merged PR must not also trigger a CLA status check",
+    );
+  });
+
+  await test("handlePullRequestTarget does nothing when a 'closed' event reports the PR was NOT merged", async () => {
+    const gh = makeFakeGitHub({
+      commits: [],
+      initialSignatures: { version: 1, signatures: [] },
+    });
+    global.fetch = gh.fetch;
+
+    const payload = {
+      action: "closed",
+      pull_request: { number: 1, merged: false, head: { sha: "head-sha-x" } },
+    };
+    await handlePullRequestTarget(payload);
+
+    assert.strictEqual(
+      gh.lockCalls.length,
+      0,
+      "a PR closed without merging must not be locked",
+    );
+    assert.strictEqual(gh.statuses.length, 0);
+  });
+
+  await test("handlePullRequestTarget does nothing for actions it doesn't care about (e.g. 'labeled')", async () => {
+    const gh = makeFakeGitHub({
+      commits: [],
+      initialSignatures: { version: 1, signatures: [] },
+    });
+    global.fetch = gh.fetch;
+
+    const payload = {
+      action: "labeled",
+      pull_request: { number: 1, merged: false, head: { sha: "x" } },
+    };
+    await handlePullRequestTarget(payload);
+
+    assert.strictEqual(gh.lockCalls.length, 0);
+    assert.strictEqual(gh.statuses.length, 0);
+  });
+
+  for (const action of ["opened", "synchronize", "reopened"]) {
+    await test(`handlePullRequestTarget on '${action}' checks the PR using the sha already on the webhook payload, without an extra GET /pulls lookup`, async () => {
+      const gh = makeFakeGitHub({
+        commits: [
+          {
+            sha: "c1",
+            author: { id: 1, login: "author" },
+            parents: [{ sha: "p1" }],
+            commit: { author: { email: "a@example.com" } },
+          },
+        ],
+        initialSignatures: {
+          version: 1,
+          signatures: [{ id: 1, login: "author" }],
+        },
+      });
+      // If checkPR() ever stopped using the sha already carried on the
+      // payload and fell back to fetching the PR itself, this would throw -
+      // that's the proof the payload's own head.sha is what actually got
+      // used, not a redundant lookup.
+      const innerFetch = gh.fetch;
+      global.fetch = async (url, opts) => {
+        if (url.includes("/pulls/1") && !url.includes("/commits")) {
+          throw new Error(
+            "must not call GET /pulls/1 when the head sha was already supplied on the webhook payload",
+          );
+        }
+        return innerFetch(url, opts);
+      };
+
+      const payload = {
+        action,
+        pull_request: { number: 1, head: { sha: "webhook-head-sha" } },
+      };
+      await handlePullRequestTarget(payload);
+
+      assert.strictEqual(gh.statuses.length, 1);
+      assert.strictEqual(gh.statuses[0].state, "success");
+      assert.strictEqual(
+        gh.statuses[0].sha,
+        "webhook-head-sha",
+        "the status must be posted against the sha from the webhook payload",
+      );
+    });
+  }
+
+  await test("a commit whose primary author has no linked GitHub account (e.g. a privacy-enabled email) is flagged for manual review by SHA, not silently skipped", async () => {
+    const gh = makeFakeGitHub({
+      commits: [
+        {
+          sha: "deadbee123456",
+          author: null, // GitHub could not match the commit's git email to any account
+          parents: [{ sha: "p1" }],
+          commit: { author: { email: "private@example.com" } },
+        },
+      ],
+      initialSignatures: { version: 1, signatures: [] },
+    });
+    global.fetch = gh.fetch;
+
+    const payload = {
+      action: "opened",
+      pull_request: { number: 1, head: { sha: "head-sha" } },
+    };
+    await handlePullRequestTarget(payload);
+
+    assert.strictEqual(gh.statuses[gh.statuses.length - 1].state, "failure");
+    const lastComment = gh.comments[gh.comments.length - 1].body;
+    assert.ok(
+      lastComment.includes("deadbee"), // short-sha form (first 7 chars)
+      "the unresolved commit's SHA must be surfaced so a maintainer can find and inspect it",
+    );
+    assert.ok(
+      lastComment.includes("could not be automatically attributed"),
+      "an author GitHub can't resolve must be flagged for manual review, never silently dropped from consideration",
+    );
+    assert.ok(
+      !lastComment.includes("private@example.com"),
+      "the raw commit email must never be posted publicly",
     );
   });
 


### PR DESCRIPTION
add more tests

## Summary by Sourcery

Expand automated coverage for GitHub API resilience and pull-request event handling.

Enhancements:
- Expose the PR-locking helper for direct integration testing.

Tests:
- Expand HTTP coverage for request timeouts, transient-error retries, rate-limit backoff, non-retryable POST failures, retry exhaustion, and malformed signature data.
- Add integration coverage for PR locking, pull-request event dispatch, webhook SHA handling, and manual review of commits without linked GitHub accounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for request timeouts, retry behavior, rate limits, and retry delays.
  - Verified that non-idempotent actions, such as posting comments, are not repeated after transient failures.
  - Added integration coverage for pull-request locking, webhook handling, commit status updates, and manual-review scenarios.
  - Added validation for malformed signature data and clearer error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->