### PR TITLE
Add zizmor workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,49 @@
+name: "GitHub Actions Security Analysis with zizmor"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "43 4 * * 1"
+  workflow_dispatch: {}
+
+env:
+  # Pin the exact release to avoid silent changes; bump manually when needed.
+  # Last checked: 2026-09-11.
+  ZIZMOR_VERSION: "1.30.1"
+
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # required for upload-sarif to publish results to the Security tab
+      contents: read # only strictly needed if this repo is ever made private
+      actions: read # only strictly needed if this repo is ever made private
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Run zizmor
+        run: uvx "zizmor@${ZIZMOR_VERSION}" --format=sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
This PR adds zizmor workflow for actions security and analysis

## Summary by Sourcery

Add scheduled and event-driven zizmor analysis to monitor GitHub Actions security.

New Features:
- Add an automated GitHub Actions security analysis workflow using zizmor on pushes, pull requests, scheduled runs, and manual dispatches.

Enhancements:
- Publish zizmor findings as SARIF results in the repository’s Security tab with restricted workflow permissions and cancelled superseded runs.