### PR TITLE
Add Actionlint workflow

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,39 @@
+name: "Lint GitHub Actions workflows"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "58 5 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actionlint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # only needed to check out the repo
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Enable actionlint inline annotations
+        run: echo "::add-matcher::.github/actionlint-matcher.json"
+
+      # Official Docker image, pinned by digest for reproducibility.
+      # Digest corresponds to v1.7.12 (latest as of 2026-09-11).
+      - name: Check workflow files with actionlint
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # v1.7.12
+        with:
+          args: -color


### PR DESCRIPTION
This PR adds actionlint workflow

## Summary by Sourcery

Add a GitHub Actions workflow to continuously validate repository workflows with actionlint.

Enhancements:
- Add automated linting for GitHub Actions workflow files on pushes, pull requests, scheduled runs, and manual dispatches.

CI:
- Configure concurrency control, inline annotations, read-only permissions, and pinned actionlint dependencies for reproducible workflow validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for GitHub Actions workflows using `actionlint`.
  * Workflow checks run on changes to the main branch, pull requests, a weekly schedule, and manual requests.
  * Validation results now provide inline annotations with file, line, column, message, and rule details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->