### PR TITLE
Add Dependabot cooldown for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This PR adds cooldown for dependabot of 7 days

## Summary by Sourcery

Enhancements:
- Add a seven-day cooldown to Dependabot updates for dependencies and GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a 7-day cooldown before Dependabot opens npm dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->