### PR TITLE
Fix: SHA val

### DIFF
--- a/src/cla-bot.js
+++ b/src/cla-bot.js
@@ -554,7 +554,7 @@ async function resolveLoginById(id) {
   if (_loginByIdCache.has(id)) return _loginByIdCache.get(id);
   let login = null;
   try {
-    const user = await gh(`/user/${id}`, GITHUB_TOKEN);
+    const user = await gh(`/user/${encodeURIComponent(id)}`, GITHUB_TOKEN);
     if (user && typeof user.login === "string" && user.login.length > 0) {
       login = user.login;
     }
@@ -639,7 +639,7 @@ async function listPRCommitAuthors(prNumber) {
   let page = 1;
   for (;;) {
     const commits = await gh(
-      `/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${prNumber}/commits?per_page=100&page=${page}`,
+      `/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${encodeURIComponent(prNumber)}/commits?per_page=100&page=${page}`,
       GITHUB_TOKEN,
     );
     if (!commits.length) break;
@@ -716,7 +716,7 @@ async function getExistingBotComments(prNumber) {
   let page = 1;
   for (;;) {
     const comments = await gh(
-      `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${prNumber}/comments?per_page=100&page=${page}`,
+      `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${encodeURIComponent(prNumber)}/comments?per_page=100&page=${page}`,
       GITHUB_TOKEN,
     );
     if (!comments.length) break;
@@ -748,7 +748,7 @@ async function postComment(prNumber, body, dedupe = true) {
     if (last && last.body === full) return; // nothing changed, don't spam the thread
   }
   await gh(
-    `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${prNumber}/comments`,
+    `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${encodeURIComponent(prNumber)}/comments`,
     GITHUB_TOKEN,
     {
       method: "POST",
@@ -795,7 +795,7 @@ async function dedupeIdenticalTrailingComments(prNumber, body) {
   for (const dup of matching.slice(0, -1)) {
     try {
       await gh(
-        `/repos/${REPO_OWNER}/${REPO_NAME}/issues/comments/${dup.id}`,
+        `/repos/${REPO_OWNER}/${REPO_NAME}/issues/comments/${encodeURIComponent(dup.id)}`,
         GITHUB_TOKEN,
         { method: "DELETE" },
       );
@@ -811,18 +811,22 @@ async function dedupeIdenticalTrailingComments(prNumber, body) {
 }
 
 async function setStatus(sha, state, description) {
-  await gh(`/repos/${REPO_OWNER}/${REPO_NAME}/statuses/${sha}`, GITHUB_TOKEN, {
-    method: "POST",
-    // Posting the same status twice has no visible effect - GitHub only
-    // shows the latest status per context - so it's fine to let gh() retry
-    // a transient failure here.
-    idempotent: true,
-    body: JSON.stringify({
-      state,
-      description: description.slice(0, 140),
-      context: STATUS_CONTEXT,
-    }),
-  });
+  await gh(
+    `/repos/${REPO_OWNER}/${REPO_NAME}/statuses/${encodeURIComponent(sha)}`,
+    GITHUB_TOKEN,
+    {
+      method: "POST",
+      // Posting the same status twice has no visible effect - GitHub only
+      // shows the latest status per context - so it's fine to let gh() retry
+      // a transient failure here.
+      idempotent: true,
+      body: JSON.stringify({
+        state,
+        description: description.slice(0, 140),
+        context: STATUS_CONTEXT,
+      }),
+    },
+  );
 }
 
 async function lockPR(prNumber) {
@@ -834,7 +838,7 @@ async function lockPR(prNumber) {
     // contract intact.
     assertValidPRNumber(prNumber, "lockPR(prNumber)");
     await gh(
-      `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${prNumber}/lock`,
+      `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${encodeURIComponent(prNumber)}/lock`,
       GITHUB_TOKEN,
       {
         method: "PUT",
@@ -854,7 +858,7 @@ async function checkPR(prNumber, headSha) {
   assertValidPRNumber(prNumber, "checkPR(prNumber)");
   if (!headSha) {
     const pr = await gh(
-      `/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${prNumber}`,
+      `/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${encodeURIComponent(prNumber)}`,
       GITHUB_TOKEN,
     );
     headSha = assertValidSha(

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -26,6 +26,7 @@ const {
   lockPR,
   postComment,
   checkPR,
+  assertValidSha,
 } = require("../src/cla-bot.js");
 
 let passed = 0;
@@ -2116,6 +2117,53 @@ function makeFakeGitHub({
     await assert.doesNotReject(() => handlePullRequestTarget(payload));
 
     assert.strictEqual(gh.statuses[gh.statuses.length - 1].state, "success");
+  });
+
+  // ---------------------------------------------------------------------
+  // encodeURIComponent() at the point of URL construction (see ghRaw()'s
+  // callers): assertValidSha's blocklist rejects structurally dangerous
+  // characters (/, .., ?, #, %, whitespace) but, by design, doesn't
+  // enforce hex-only content - so a sha containing e.g. "&" legitimately
+  // passes validation. Unencoded, that "&" would be able to inject or
+  // override query parameters on any request built from it. This test
+  // proves percent-encoding is genuinely applied at the sink (not just
+  // present in the source and inert), by checking the literal bytes that
+  // reach fetch().
+  // ---------------------------------------------------------------------
+  await test("checkPR percent-encodes a validator-legal but URL-significant sha (containing '&') before it ever reaches fetch(), so it can't inject or override a query parameter", async () => {
+    const gh = makeFakeGitHub({
+      commits: [],
+      initialSignatures: { version: 1, signatures: [] },
+    });
+    const trickySha = "abc&page=999&per_page=1";
+    assert.doesNotThrow(
+      () => assertValidSha(trickySha, "sanity check"),
+      "this test only proves something if the tricky value is legal input to begin with",
+    );
+
+    let observedRawUrl = null;
+    const innerFetch = gh.fetch;
+    global.fetch = async (url, opts) => {
+      if (url.includes("/statuses/")) observedRawUrl = url;
+      return innerFetch(url, opts);
+    };
+
+    const payload = {
+      action: "opened",
+      pull_request: { number: 1, head: { sha: trickySha } },
+    };
+    await assert.doesNotReject(() => handlePullRequestTarget(payload));
+
+    assert.ok(observedRawUrl, "expected a status request to have been made");
+    assert.strictEqual(
+      observedRawUrl.split("/statuses/")[1],
+      encodeURIComponent(trickySha),
+      "the sha must reach fetch() percent-encoded, not as raw, URL-significant characters",
+    );
+    assert.strictEqual(
+      gh.statuses[gh.statuses.length - 1].sha,
+      encodeURIComponent(trickySha),
+    );
   });
 
   console.log(`\n${passed} test(s) passed.`);


### PR DESCRIPTION
This PR fixes SHA validation

## Summary by Sourcery

Harden GitHub API path construction so validated identifiers cannot inject or override URL parameters.

Bug Fixes:
- Prevent URL-significant SHA values from altering GitHub status API requests by percent-encoding them before use.

Enhancements:
- Percent-encode identifiers used in GitHub API paths, including user IDs, pull request numbers, and comment IDs.

Tests:
- Add integration coverage verifying that validator-legal but URL-significant SHA values are percent-encoded before reaching the request layer.