### PR TITLE
Fix:improve sign method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ break or get abandoned.
    in a commit message, not just the main author. If someone hasn't signed,
    it comments with instructions and marks the PR's `cla/fossasia` check as
    failing.
-3. The contributor replies on the PR with the exact sign phrase.
+3. The contributor replies to the bot's comment with the exact sign
+   phrase. A plain new comment doesn't count.
 4. The bot saves the signature (in `fossasia/cla-signatures`) and re-checks
    the PR. Once everyone has signed, the check turns green.
 5. Since the signature list is shared across the whole org, signing once

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -137,12 +137,15 @@ access control from Step 2.
 2. Open a test PR - ideally from a second GitHub account, so you're
    testing what a real external contributor would see.
 3. The bot should comment listing the missing signers.
-4. Sign by commenting exactly: `I have read the CLA Document and I hereby sign the CLA`
+4. Sign by replying to the bot's comment with exactly:
+   `I have read the CLA Document and I hereby sign the CLA`.
+   A plain new comment will not count.
 5. Confirm a new entry showed up in `cla-signatures`.
-6. **Impersonation test**: on a different PR, comment the sign phrase from
-   a third account and check the PR does _not_ get marked as signed
-   (unless that commenter is actually the PR's commit author). This is
-   already covered by the bot's own test suite, but it's worth confirming
+6. **Impersonation test**: on a different PR, reply to the bot's comment
+   with the sign phrase from a third account and check the PR does _not_
+   get marked as signed (unless that commenter is actually the PR's commit
+   author). This is already covered by the bot's own test suite, but it's
+   worth confirming
    once against a real PR too.
 
 ## Step 8 - Roll out across the whole org

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -109,7 +109,8 @@ but double-check if you've modified it.
 
 ### 1.6 Sign and confirm
 
-Comment exactly this on the PR:
+Reply to the bot's comment with exactly this text - a plain new comment
+will not count:
 
 ```
 I have read the CLA Document and I hereby sign the CLA
@@ -206,15 +207,15 @@ Add secrets to both repos (`Settings → Secrets and variables → Actions`):
 
 ### 2.5 Edge case tests (checking specific fixes)
 
-| Test                       | How to do it                                                                                                                                          | Expected result                                                                                                                                          |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Impersonation guard        | From a second/alt GitHub account, comment the sign phrase on a PR where you are the commit author                                                    | The PR should **not** turn green - only the commenter signed, not the real author                                                                       |
-| `recheck` authorization    | From an alt account (not the PR author), comment `recheck` on a PR                                                                                    | The bot should give **no response** (silently ignored)                                                                                                  |
-| `recheck` legitimate       | The PR author themselves comments `recheck`                                                                                                            | The bot re-evaluates and responds                                                                                                                        |
-| Merge-commit exclusion     | Click GitHub's "Update branch" button on a PR (this creates a merge commit)                                                                            | The person who clicked that button should not be asked to sign                                                                                          |
-| Malformed-entry resilience | Manually edit `signatures/cla.json` in `cla-signatures`, remove the `login` field from one entry, commit it                                            | The next PR check should still work normally (no crash), and the Actions logs should show a `::warning::` about the malformed entry                    |
+| Test                       | How to do it                                                                                                                                          | Expected result                                                                                                                                           |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Impersonation guard        | From a second/alt GitHub account, comment the sign phrase on a PR where you are the commit author                                                     | The PR should **not** turn green - only the commenter signed, not the real author                                                                         |
+| `recheck` authorization    | From an alt account (not the PR author), comment `recheck` on a PR                                                                                    | The bot should give **no response** (silently ignored)                                                                                                    |
+| `recheck` legitimate       | The PR author themselves comments `recheck`                                                                                                           | The bot re-evaluates and responds                                                                                                                         |
+| Merge-commit exclusion     | Click GitHub's "Update branch" button on a PR (this creates a merge commit)                                                                           | The person who clicked that button should not be asked to sign                                                                                            |
+| Malformed-entry resilience | Manually edit `signatures/cla.json` in `cla-signatures`, remove the `login` field from one entry, commit it                                           | The next PR check should still work normally (no crash), and the Actions logs should show a `::warning::` about the malformed entry                       |
 | First-write race           | Open PRs in two different consumer repos that have never had anyone sign before, and have two different people sign on each at close to the same time | Both signatures should end up recorded - neither should be lost, even though both writes are trying to create the signatures file for the very first time |
-| Duplicate-signature race   | (Optional, advanced) Try sending the same sign comment twice in quick succession                                                                      | `signatures/cla.json` should not end up with a duplicate entry - this is already covered by the code-level tests, so this manual check is optional      |
+| Duplicate-signature race   | (Optional, advanced) Try sending the same sign comment twice in quick succession                                                                      | `signatures/cla.json` should not end up with a duplicate entry - this is already covered by the code-level tests, so this manual check is optional        |
 
 For the alt account: any second GitHub account works (a friend's, or a
 second account of your own) - all it needs to do is comment on your

--- a/src/cla-bot.js
+++ b/src/cla-bot.js
@@ -902,9 +902,11 @@ async function checkPR(prNumber, headSha) {
     missing.forEach((a) => lines.push(`- @${a.login}`));
     lines.push(
       "",
-      "Please comment on this PR with **exactly** the following text to sign:",
+      "To sign, **reply to this comment** with **exactly** the following text:",
       "",
       `> ${SIGN_PHRASE}`,
+      "",
+      "A plain new comment that doesn't quote this one will not be accepted.",
       "",
       "Signing once covers **all** FOSSASIA repositories - you will not be asked again.",
     );
@@ -948,6 +950,45 @@ function isPrivileged(payload, commenter) {
   return ["OWNER", "MEMBER", "COLLABORATOR"].includes(association);
 }
 
+// A sign-phrase comment only counts as a sign if it's shown to be a reply
+// to this bot's own comment - see handleIssueComment() below for why.
+// GitHub's Conversation tab has no real reply/thread id on issue_comment
+// webhooks (a roadmap request for that was closed as "not planned" - see
+// github/roadmap#552), so "reply" is approximated the only way the raw text
+// makes possible: a leading blockquoted block that itself quotes
+// BOT_MARKER. That's exactly what GitHub's own "Quote reply" inserts, and
+// it's also what a contributor gets if they manually quote the comment by
+// hand instead - both produce the same shape, so one check covers both.
+function isQuotedBotReply(rawBody) {
+  return rawBody.split("\n").some((line) => {
+    const trimmed = line.trimStart();
+    if (!trimmed.startsWith(">")) return false;
+    // Strip all leading '>' markers (handles a nested quote too, e.g. the
+    // sign phrase in our own comment is itself already inside a '>' block,
+    // so quoting our whole comment back to us produces '> > ...' there).
+    return trimmed.replace(/^(>\s?)+/, "").includes(BOT_MARKER);
+  });
+}
+
+// The part of the comment the contributor actually typed themselves: GitHub
+// (and a contributor manually mimicking the same shape) puts the quoted
+// block first and the new text below it, so this strips the leading run of
+// blank/quoted lines from the very start of the comment and returns
+// whatever's left, trimmed.
+function replyText(rawBody) {
+  const lines = rawBody.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    const trimmed = lines[i].trimStart();
+    if (trimmed === "" || trimmed.startsWith(">")) {
+      i++;
+    } else {
+      break;
+    }
+  }
+  return lines.slice(i).join("\n").trim();
+}
+
 async function handleIssueComment(payload) {
   if (!payload.issue || !payload.issue.pull_request) return; // comment on a plain issue, not a PR
   if (
@@ -966,10 +1007,17 @@ async function handleIssueComment(payload) {
     payload.issue.number,
     "issue_comment payload issue.number",
   );
-  const body = (payload.comment.body || "").trim();
+  const rawBody = payload.comment.body || "";
+  const body = rawBody.trim();
   const commenter = payload.comment.user.login;
 
-  if (body.toLowerCase() === SIGN_PHRASE.toLowerCase()) {
+  // Must be a reply (quoting this bot's comment - see isQuotedBotReply())
+  // whose own typed text is exactly the sign phrase - a bare new comment
+  // that just happens to say the phrase, with nothing quoted, is ignored.
+  if (
+    isQuotedBotReply(rawBody) &&
+    replyText(rawBody).toLowerCase() === SIGN_PHRASE.toLowerCase()
+  ) {
     const sigToken = await getSignaturesToken();
     // The webhook already carries the commenter's numeric id - recording
     // that, not just the login, is what lets the signature survive a later

--- a/src/cla-bot.js
+++ b/src/cla-bot.js
@@ -1153,11 +1153,8 @@ module.exports = {
   postComment,
   validateConfig,
   lockPR,
-  // Exported for tests only, same as everything above - not part of the
-  // action's public contract. Covered directly in test/logic.test.js so a
-  // future change to either validator's character rules (e.g. UNSAFE_URL_
-  // SEGMENT_RE) fails immediately and specifically, rather than only being
-  // caught indirectly through the webhook-handler integration tests.
   assertValidPRNumber,
   assertValidSha,
+  isQuotedBotReply,
+  replyText,
 };

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -353,7 +353,7 @@ function baseEnv(apiUrl) {
       },
       comment: {
         user: { id: 42, login: "e2e-author" },
-        body: "I have read the CLA Document and I hereby sign the CLA",
+        body: "> <!-- fossasia-cla-bot:v1 -->\n> Please comment on this PR to sign.\n\nI have read the CLA Document and I hereby sign the CLA",
         html_url: "https://example.com/comment",
         author_association: "NONE",
       },

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -215,7 +215,10 @@ function makeFakeGitHub({
       issue: { number: 1, pull_request: {}, user: { login: "alice" } },
       comment: {
         user: { id: 1001, login: "alice" },
-        body: "I have read the CLA Document and I hereby sign the CLA",
+        // Simulates GitHub's "Quote reply" (or a contributor manually
+        // quoting the bot's comment): a leading '>' block quoting the
+        // bot's marker, then the sign phrase below it.
+        body: "> <!-- fossasia-cla-bot:v1 -->\n> Please comment on this PR to sign.\n\nI have read the CLA Document and I hereby sign the CLA",
         html_url: "https://github.com/fossasia/testrepo/pull/1#issuecomment-1",
         author_association: "NONE",
       },
@@ -262,7 +265,7 @@ function makeFakeGitHub({
       issue: { number: 1, pull_request: {}, user: { login: "real-author" } },
       comment: {
         user: { id: 9999, login: "random-commenter" }, // NOT the commit author
-        body: "I have read the CLA Document and I hereby sign the CLA",
+        body: "> <!-- fossasia-cla-bot:v1 -->\n> Please comment on this PR to sign.\n\nI have read the CLA Document and I hereby sign the CLA",
         html_url: "https://github.com/fossasia/testrepo/pull/1#issuecomment-2",
         author_association: "NONE",
       },
@@ -886,7 +889,7 @@ function makeFakeGitHub({
       issue: { number: 1, pull_request: {}, user: { login: "alice" } },
       comment: {
         user: { id: 8001, login: "alice" },
-        body: "I have read the CLA Document and I hereby sign the CLA",
+        body: "> <!-- fossasia-cla-bot:v1 -->\n> Please comment on this PR to sign.\n\nI have read the CLA Document and I hereby sign the CLA",
         html_url: "x",
         author_association: "NONE",
       },

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -284,6 +284,14 @@ function makeFakeGitHub({
       lastComment.includes("@real-author"),
       "the missing-signer list must name the real author, not the commenter",
     );
+    assert.ok(
+      lastComment.includes("reply to this comment"),
+      "the sign instructions must tell contributors to reply, matching the quoted-reply gate in handleIssueComment",
+    );
+    assert.ok(
+      !lastComment.includes("comment on this PR with"),
+      "the old (pre quoted-reply) instruction wording must not still be present",
+    );
   });
 
   await test("merge commits do not require the person who merged to sign", async () => {
@@ -905,6 +913,102 @@ function makeFakeGitHub({
     // First call: 1 "all signed" comment. Second call: 1 "already signed" comment.
     assert.strictEqual(gh.comments.length, 2);
     assert.ok(gh.comments[1].body.includes("already signed"));
+  });
+
+  // -------------------------------------------------------------------
+  // Quoted-reply sign gate: negative paths. handleIssueComment() must
+  // treat every one of these exactly like an unrelated comment - no
+  // signature written, no comment posted, no status set, and (via
+  // fetchThatMustNotBeCalled) no network call made at all. Positive-path
+  // coverage (a real quoted reply signing successfully) is the "sole
+  // commit author" and "signing twice" tests above; the pure matching
+  // logic (isQuotedBotReply/replyText) has its own unit tests in
+  // test/logic.test.js.
+  // -------------------------------------------------------------------
+  const BOT_MARKER = "<!-- fossasia-cla-bot:v1 -->";
+
+  async function assertSignIsIgnored(name, body) {
+    await test(name, async () => {
+      global.fetch = fetchThatMustNotBeCalled;
+      const payload = {
+        action: "created",
+        issue: { number: 1, pull_request: {}, user: { login: "alice" } },
+        comment: {
+          user: { id: 1, login: "alice" },
+          body,
+          html_url: "x",
+          author_association: "NONE",
+        },
+      };
+      // Must not throw, and - proven by fetchThatMustNotBeCalled above -
+      // must not make any network request either (no write, no comment,
+      // no status).
+      await assert.doesNotReject(() => handleIssueComment(payload));
+    });
+  }
+
+  await assertSignIsIgnored(
+    "a plain sign-phrase comment with NO quote at all is ignored, not treated as a sign",
+    "I have read the CLA Document and I hereby sign the CLA",
+  );
+
+  await assertSignIsIgnored(
+    "a quoted comment whose quoted block does NOT contain the bot marker is ignored (quoting some other comment doesn't count)",
+    "> this is someone else's comment, not the bot's\n\nI have read the CLA Document and I hereby sign the CLA",
+  );
+
+  await assertSignIsIgnored(
+    "a properly quoted reply with extra trailing text after the sign phrase is ignored - the phrase must be exact",
+    `> ${BOT_MARKER}\n\nI have read the CLA Document and I hereby sign the CLA, thanks!`,
+  );
+
+  await assertSignIsIgnored(
+    "a properly quoted reply with extra leading text before the sign phrase is ignored - the phrase must be exact",
+    `> ${BOT_MARKER}\n\nOk, I have read the CLA Document and I hereby sign the CLA`,
+  );
+
+  await assertSignIsIgnored(
+    "the sign phrase typed BEFORE the quoted block (reversed order) is ignored - only a LEADING quote block is recognized",
+    `I have read the CLA Document and I hereby sign the CLA\n\n> ${BOT_MARKER}`,
+  );
+
+  await assertSignIsIgnored(
+    "a properly quoted bot marker with nothing typed after it is ignored - quoting alone is not a sign",
+    `> ${BOT_MARKER}\n> Please comment on this PR to sign.`,
+  );
+
+  await test("a quoted reply with the sign phrase in a different case still signs successfully - case-insensitivity survives the new quote-reply gate", async () => {
+    const gh = makeFakeGitHub({
+      commits: [
+        {
+          sha: "c1",
+          author: { id: 7001, login: "alice" },
+          parents: [{ sha: "p1" }],
+          commit: { author: { email: "alice@example.com" } },
+        },
+      ],
+      initialSignatures: { version: 1, signatures: [] },
+    });
+    global.fetch = gh.fetch;
+
+    const payload = {
+      action: "created",
+      issue: { number: 1, pull_request: {}, user: { login: "alice" } },
+      comment: {
+        user: { id: 7001, login: "alice" },
+        body: `> ${BOT_MARKER}\n\ni HAVE READ the cla document and i hereby SIGN the cla`,
+        html_url: "x",
+        author_association: "NONE",
+      },
+    };
+    await handleIssueComment(payload);
+
+    assert.strictEqual(
+      gh.signatures.signatures.length,
+      1,
+      "signature should still be recorded despite the case difference",
+    );
+    assert.strictEqual(gh.signatures.signatures[0].login, "alice");
   });
 
   await test("a spoofed comment from a regular user cannot fool the dedupe check into suppressing the real bot comment", async () => {

--- a/test/logic.test.js
+++ b/test/logic.test.js
@@ -23,6 +23,8 @@ const {
   isPrivileged,
   assertValidPRNumber,
   assertValidSha,
+  isQuotedBotReply,
+  replyText,
 } = require("../src/cla-bot.js");
 
 let passed = 0;
@@ -585,6 +587,102 @@ test("assertValidSha accepts exactly 64 characters (the sha256 boundary) but rej
   assert.throws(
     () => assertValidSha("a".repeat(65), "ctx"),
     /expected a valid commit SHA/,
+  );
+});
+
+// --- isQuotedBotReply / replyText: the quoted-reply sign gate -------------
+// GitHub's Conversation tab has no real reply/thread id on issue_comment
+// webhooks, so a "reply" is approximated as a leading blockquoted block
+// that itself quotes BOT_MARKER (see the design note above
+// isQuotedBotReply() in src/cla-bot.js). These are pure-function unit tests
+// of that matching, independent of the full handleIssueComment() wiring
+// (which is covered separately, end-to-end, in test/integration.test.js).
+const BOT_MARKER = "<!-- fossasia-cla-bot:v1 -->";
+
+test("isQuotedBotReply is true when a quoted line contains the bot marker", () => {
+  assert.strictEqual(
+    isQuotedBotReply(`> ${BOT_MARKER}\n\nI have read the CLA`),
+    true,
+  );
+});
+
+test("isQuotedBotReply is false when there is no quoted line at all", () => {
+  assert.strictEqual(
+    isQuotedBotReply("I have read the CLA Document and I hereby sign the CLA"),
+    false,
+  );
+});
+
+test("isQuotedBotReply is false when a quoted line exists but does not contain the bot marker", () => {
+  assert.strictEqual(
+    isQuotedBotReply("> just some other quoted text\n\nI have read the CLA"),
+    false,
+  );
+});
+
+test("isQuotedBotReply is false when the marker text appears WITHOUT a leading '>' - pasting the raw marker is not the same as quoting it", () => {
+  assert.strictEqual(
+    isQuotedBotReply(`${BOT_MARKER}\n\nI have read the CLA`),
+    false,
+  );
+});
+
+test("isQuotedBotReply is true for a nested/double-quoted marker line (quoting a comment that already quoted something)", () => {
+  assert.strictEqual(isQuotedBotReply(`> > ${BOT_MARKER}\n\ntext`), true);
+});
+
+test("isQuotedBotReply is true when the '>' is preceded by leading whitespace", () => {
+  assert.strictEqual(isQuotedBotReply(`   > ${BOT_MARKER}`), true);
+});
+
+test("isQuotedBotReply is true when the marker line is not the first line of the comment", () => {
+  assert.strictEqual(
+    isQuotedBotReply(`> some other quoted line\n> ${BOT_MARKER}\n\ntext`),
+    true,
+  );
+});
+
+test("isQuotedBotReply is false for an empty body", () => {
+  assert.strictEqual(isQuotedBotReply(""), false);
+});
+
+test("replyText returns the trimmed whole body when there is no leading quote block at all", () => {
+  assert.strictEqual(
+    replyText("  I have read the CLA Document and I hereby sign the CLA  "),
+    "I have read the CLA Document and I hereby sign the CLA",
+  );
+});
+
+test("replyText strips a single-line leading quote block", () => {
+  assert.strictEqual(replyText("> quoted line\n\nreply text"), "reply text");
+});
+
+test("replyText strips a multi-line leading quote block, including blank '>' continuation lines inside it", () => {
+  assert.strictEqual(
+    replyText("> line1\n>\n> line2\n\nreply text"),
+    "reply text",
+  );
+});
+
+test("replyText treats a blank line with no '>' prefix as still part of the leading quote/skip region", () => {
+  assert.strictEqual(replyText("> quoted\n\n\nreply text"), "reply text");
+});
+
+test("replyText returns an empty string when the whole body is quoted with nothing typed afterward", () => {
+  assert.strictEqual(replyText("> quoted line\n> another quoted line"), "");
+});
+
+test("replyText does NOT strip a quote block that comes after the reply text - only a LEADING quote block counts", () => {
+  assert.strictEqual(
+    replyText("reply text\n\n> quoted line"),
+    "reply text\n\n> quoted line",
+  );
+});
+
+test("replyText only trims the outer edges, preserving internal formatting of the actual reply", () => {
+  assert.strictEqual(
+    replyText("> q\n\nline one\nline two  "),
+    "line one\nline two",
   );
 });
 


### PR DESCRIPTION
## Summary by Sourcery

Require contributors to sign the CLA by replying to the bot's signing comment with the exact signature phrase.

Bug Fixes:
- Require CLA signatures to be submitted as replies quoting the bot's comment, preventing standalone or unrelated comments from being accepted.

Enhancements:
- Make signature validation require the exact phrase in the contributor's reply text while supporting GitHub's quoted and nested reply formats.

Documentation:
- Update the README, setup guide, and testing guide to document the quoted-reply signing workflow and validation expectations.

Tests:
- Add unit, integration, and end-to-end coverage for valid quoted replies, invalid signing comments, exact phrase matching, and case-insensitive acceptance.